### PR TITLE
Fix renovate config and CI

### DIFF
--- a/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
+++ b/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
     paths:
-      - "configs"
+      - "package.json"
+      - "package-lock.json"
 
 jobs:
   dummy:

--- a/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
+++ b/.github/workflows/dummy-for-automerge-minor-renovate-update.yaml
@@ -1,0 +1,15 @@
+name: dummy check for merging automatically PR updating minor or patch update 
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "configs"
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: dummy
+        run: echo "dummy"

--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>dataware-tools/renovate-config",
-    ":automergeMinor",
-    ":skipStatusChecks"
+    ":automergeMinor"
   ],
   "reviewers": ["WatanabeToshimitsu"]
 }


### PR DESCRIPTION
## What?
Fix renovate config and CI

## Why?
:skipStatusCheck だと、意図せずメジャーアップデートも自動でマージしたいたから