### PR TITLE
Ignore auto experimental packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,7 @@
     "github>dataware-tools/renovate-config",
     ":automergeMinor"
   ],
-  "reviewers": ["WatanabeToshimitsu"]
+  "reviewers": ["WatanabeToshimitsu"],
+  "ignoreDeps": ["loki", "msw"]
+
 }


### PR DESCRIPTION
## What?
Ignore experimental packages

## Why?
メジャーバージョンが 0 のライブラリは、マイナーアップデートでも破壊的変更を入れてくるから