### PR TITLE
Set bump strategy to peerDeps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
     "github>dataware-tools/renovate-config",
     ":automergeMinor"
   ],
+  "packageRules": [ {
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "bump"
+    }],
   "reviewers": ["WatanabeToshimitsu"]
 }


### PR DESCRIPTION
## What?
Set bump strategy to peerDeps

## Why?
デフォルトでは、peerDeps の rangeStrategy が widen になっていて、メジャーアップデートの時に意図と異なる動きをするから
https://docs.renovatebot.com/configuration-options/#rangestrategy